### PR TITLE
ci: enforce least-privilege permissions for GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Enforce least-privilege permissions

This PR adds explicit `permissions` blocks to GitHub Actions workflow files that currently have no permissions defined, following the principle of least privilege.

### Changes
- `ci.yaml`: contents: read

### Why
Without explicit permissions, workflows inherit the default token permissions configured at the repository or organization level. By explicitly declaring the minimum required permissions, we reduce the blast radius if a workflow is compromised.

### References
- [GitHub Actions security hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- [Automatic token authentication permissions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)
